### PR TITLE
Adds agent name substitution for URLs

### DIFF
--- a/src/main/java/de/qucosa/dissemination/epicur/model/EpicurBuilder.java
+++ b/src/main/java/de/qucosa/dissemination/epicur/model/EpicurBuilder.java
@@ -18,6 +18,7 @@ import org.jdom2.xpath.XPathFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,6 +44,7 @@ public class EpicurBuilder {
     private Document metsDocument;
     private String transferUrlPattern;
     private UpdateStatus updateStatus = UpdateStatus.urn_new;
+    private Map<String, String> agentNameSubstitutions = Collections.emptyMap();
 
     public EpicurBuilder transferUrlPattern(String pattern) {
         transferUrlPattern = pattern;
@@ -51,6 +53,11 @@ public class EpicurBuilder {
 
     public EpicurBuilder frontpageUrlPattern(String pattern) {
         frontpageUrlPattern = pattern;
+        return this;
+    }
+
+    public EpicurBuilder agentNameSubstitutions(Map<String, String> agentNameSubstitutions) {
+        this.agentNameSubstitutions = agentNameSubstitutions;
         return this;
     }
 
@@ -219,7 +226,12 @@ public class EpicurBuilder {
     private String extractAgentName(Document metsDocument) {
         Element agentNameElement = (Element) XPATH_AGENT.evaluateFirst(metsDocument);
         if (agentNameElement != null) {
-            return agentNameElement.getTextTrim();
+            String agentName = agentNameElement.getTextTrim();
+            if (agentNameSubstitutions.containsKey(agentName)) {
+                return agentNameSubstitutions.get(agentName);
+            } else {
+                return agentName;
+            }
         }
         return null;
     }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -42,6 +42,11 @@
         <param-value>fedoraAdmin:fedoraAdmin</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>agent.substitutions</param-name>
+        <param-value>ubc=monarch ; ubl=ul</param-value>
+    </context-param>
+
     <servlet>
         <servlet-name>EpicurDisseminatorServlet</servlet-name>
         <servlet-class>de.qucosa.dissemination.epicur.servlet.EpicurDisseminationServlet</servlet-class>


### PR DESCRIPTION
METS agent names can be used for generating fontpage and transfer URL
links. This commit introduces a context configuration parameter which
allows to define a set of substitutions.

Resolves https://jira.slub-dresden.de/browse/CMR-417